### PR TITLE
Refined Per_AOI_Data_Compiler Program

### DIFF
--- a/file-scripts/Per_AOI_Data_Compiler/PilotDataCompiler/src/App.java
+++ b/file-scripts/Per_AOI_Data_Compiler/PilotDataCompiler/src/App.java
@@ -1,29 +1,36 @@
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
-public class App {
-    static ArrayList<List<String>> allData;
-    static ArrayList<String> headers;
-    static boolean doneHeaders;
-    /* To run this: 
+/**
+    Aggregates the participants' AOI data into 1 file per AOI and 1 combined file with all data. 
+    To run this: 
     1. Configure the paths below
     2. Verify all the desired participants are listed in DataConfig.java (the participantID variable). This shouldn't need to be changed unless new participants are added in the future.
     3. Verify all AOIs are listed in DataConfig.java (the aoiNames variable). This also shouldn't need changing unless new AOIs are added in the future.
-    4. Run the program. 
-    NOTE: If you are re-running this code, make sure none of the output files from a previous run are open, as the code won't be able to overwrite any currently opened files. */
-    private static final String DATAPATH = "C:/Users/Productivity/Documents/D2 Lab/DataCompiler/Data"; //Path to the folder containing the input
-    private static final String PILOT_CSV_PATH = DATAPATH + "/ILS_Pilot_Data_with_all_DGMs.csv"; //Path to the All_Pilot_Data CSV file
-    private static final String DGM_FOLDER = DATAPATH + "/ILS Approach DGMs (Single AOI)"; //Location of folder containing all the individually run DGMs (can be downloaded from the sharepoint as "ILS Approach DGMs (Single AOI)"
-    private static final String OUTPUT_FOLDER = DATAPATH + "/Output"; //Output folder for all resulting CSVs to be generated in
-
+    4. Comment out code as needed (e.g., remove allData if you only want the AOI specific data)
+    5. Run the program. 
+    NOTE: If you are re-running this code, make sure none of the output files from a previous run are open, as the code won't be able to overwrite any currently opened files. 
+    NOTE: You may need to configure the java project's reference libraries settings in your IDE if it does not automatically detect the jar file.
+*/
+public class App {
+    static ArrayList<List<String>> allData = new ArrayList<>();
+    static ArrayList<String> headers;
+    static boolean doneHeaders;
+    private static final String DATA_PATH = "/Users/ashleyjones/Documents/CSULB/EyeTracking/Data"; //Path to the folder containing the input
+    private static final String DGM_FOLDER = DATA_PATH + "/Gaze Analysis Results"; //Location of folder containing all the individually run DGMs (can be downloaded from the sharepoint as "ILS Approach DGMs (Single AOI)"
+    private static final String OUTPUT_FOLDER = DATA_PATH + "/Output"; //Output folder for all resulting CSVs to be generated in
+    private static final String PILOT_CSV_PATH = DATA_PATH + "/ILS_Pilot_Data_with_all_DGMs.csv"; //Path to the All_Pilot_Data CSV file
     private static final int PILOT_COLUMNS = 58; //Number of columns to take from the All_Pilot_Data file. 58 columns includes all data prior to the overall approach DGMs.
     public static void main(String[] args) throws Exception {
         System.out.println("Beginning data compilation");
         doneHeaders = false; //Headers are taken from the existing files as the software runs. This flag ensures they are only copied over once.
         headers = new ArrayList<>();
+        Files.createDirectories(Paths.get(OUTPUT_FOLDER));
         allData = CSVHandler.csvToArrayList(PILOT_CSV_PATH);
-
         ArrayList<List<String>> outputData = new ArrayList<>();
         for (int j = 0; j < DataConfig.aoiNames.length; j++) { //Iterate through all AOI names
             String aoiName = DataConfig.aoiNames[j];
@@ -34,13 +41,18 @@ public class App {
                 outputData.add(results);
                 singleAOIData.add(results);
             }
-            singleAOIData.addAll(0,Arrays.asList(headers));
+
+            String aoiNoSpaces = aoiName.replace(" ", "");
+            List<String> aoiHeaders = new LinkedList<>();
+            for (String h : headers) {
+                aoiHeaders.add(h.replaceFirst("aoi", aoiNoSpaces));
+            }
+
+            singleAOIData.addAll(0,Arrays.asList(aoiHeaders));
             CSVHandler.writeToCSV(singleAOIData, OUTPUT_FOLDER + "/AOI_"+ aoiName +"_Pilot_Data.csv"); //Outputs the file for a single AOI
-            
         }
 
         outputData.addAll(0,Arrays.asList(headers));
-
         CSVHandler.writeToCSV(outputData, OUTPUT_FOLDER + "/AOI_Combined_Pilot_Data.csv"); //Outputs the file for all the combines AOIs.
         System.out.println("Data compilation completed.");
     }
@@ -56,10 +68,10 @@ public class App {
         }
         
         
-        String participantFolder = DGM_FOLDER + "/" + pID + "_approach"; //The folder containing the various CSVs for a particular participant
-        String pIDPath = participantFolder + "/" + pID + "_approach_"; //Locates the folder containing DGMs for the current participant ID
-        String dgmPath = pIDPath + "AOI_DGMs.csv"; //Locates the participants AOI DGM file.
-        String transitionPath = pIDPath + "AOI_Transitions.csv"; //Locates the participants AOI transition file.
+        String participantFolder = DGM_FOLDER + "/" + pID; //The folder containing the various CSVs for a particular participant
+        String pIDPath = participantFolder + "/" + pID; //Locates the folder containing DGMs for the current participant ID
+        String dgmPath = pIDPath + "_AOI_DGMs.csv"; //Locates the participants AOI DGM file.
+        String transitionPath = pIDPath + "_AOI_Transitions.csv"; //Locates the participants AOI transition file.
 
 
         ArrayList<List<String>> dgm = CSVHandler.csvToArrayList(dgmPath);
@@ -75,23 +87,23 @@ public class App {
 
         if (!doneHeaders) { //Adds AOI DGM headers if they have not been added already
             for (int i = 0; i < dgm.get(0).size(); i++) {
-                headers.add(processHeader("aoi_"+dgm.get(0).get(i)));
+                headers.add(processHeader("aoi_" + dgm.get(0).get(i)));
             }
         }
 
         ArrayList<List<String>> transitionData = CSVHandler.csvToArrayList(transitionPath);
 
         for (int i = 0; i < DataConfig.aoiNames.length; i++) { //Iterates overall all AOI names
-            String fromAOI = DataConfig.aoiNames[i];
+            String toAOI = DataConfig.aoiNames[i];
             if (!doneHeaders) { //Adds AOI transition headers if they have not been added already.
-                headers.add(processHeader("aoi_Pair from " + fromAOI));
-                headers.add(processHeader("aoi_Transitions count from " + fromAOI));
-                headers.add(processHeader("aoi_Proportion including self-transitions from " + fromAOI));
-                headers.add(processHeader("aoi_Proportion excluding self-transitions from " + fromAOI));
+                headers.add(processHeader("aoi_to_" + toAOI));
+                headers.add(processHeader("aoi_to_" + toAOI + "_Transitions_count"));
+                headers.add(processHeader("aoi_to_" + toAOI + "_Proportion_including_self-transitions"));
+                headers.add(processHeader("aoi_to_" + toAOI + "_Proportion_excluding_self-transitions"));
             }
             for (int j = 0; j < transitionData.size(); j++) { //Adds transition data to the file if the line matches the current AOI pair (fromAOI to aoiName)
                 List<String> transition = transitionData.get(j);
-                if (transition.get(0).contains(fromAOI + " -> " + aoiName)) { 
+                if (transition.get(0).contains(aoiName + " -> " + toAOI)) { 
                     result.add(transition.get(0));
                     result.add(transition.get(1));
                     result.add(transition.get(2));


### PR DESCRIPTION
Updated the java program that aggregates the participant AOI data into 1 file per AOI.

Code originally grouped the transitions based on the AOI the participant transitioned to (i.e., the second AOI in the pair). Now the transitions are grouped based on the first AOI in the pair. This is to better match the definition of AOI transition proportions (Proportion of A->B, A->C, A->D all add to 1).

Additionally, the csv files use the actual AOI name rather a default "aoi" in the headers. The combined file still uses "aoi" because there are multiple AOIs.

Example Header: 
> - AI_average_pupil_size_of_right_eye
> - AI_to_No_AOI_Proportion_excluding_self-transitions

Hopefully this will help keep our data analysis and SPSS outputs more organized.

*Note: I also removed the hardcoded "_approach_" in the `App.java` file to make the java program more reusable in the future. Researchers will be responsible for adding additional file naming schemes to the `DataConfig.java` themselves.